### PR TITLE
Enforce LF in the repo.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,6 @@ jobs:
         node: [14, 12]
 
     steps:
-    - name: Set git to use LF
-      if: ${{ matrix.os == 'windows-latest' }}
-      run: |
-        git config --global core.autocrlf false
-        git config --global core.eol lf
     - uses: actions/checkout@v2.3.4
     - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v2.4.1


### PR DESCRIPTION
On Windows `autocrlf: true` is the default which makes the linter sad.

This affects any Windows user who clone the repo, so this change fixes the issue properly.