### PR TITLE
Move support to node 16 and npm 8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
         required: true
 
 env:
-  NODE_VERSION: 14
+  NODE_VERSION: 'lts/*'
   FORCE_COLOR: 2
 
 jobs:
@@ -29,7 +29,7 @@ jobs:
       - run: git status # getting odd dirty repo errors during version debug info
       - run: git diff
       - name: npm version && npm publish
-        uses: bcomnes/npm-bump@v2
+        uses: bcomnes/npm-bump@v2.0.2
         with:
           git_email: bcomnes@gmail.com
           git_username: ${{ github.actor }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        node: [14, 12]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node: ['lts/*', 18]
 
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "docs"
   ],
   "engines": {
-    "node": ">= 10"
+    "node": ">= 16",
+    "npm": ">= 8"
   },
   "scripts": {
     "_mocha": "mocha --timeout 120000",

--- a/test/package-config.js
+++ b/test/package-config.js
@@ -9,6 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
+const { execSync } = require("child_process")
 const assert = require("assert").strict
 const nodeApi = require("../lib")
 const util = require("./lib/util")
@@ -28,81 +29,87 @@ describe("[package-config] it should have an ability to overwrite package's conf
 
     beforeEach(removeResult)
 
-    it("Node API should address \"packageConfig\" option", async () => {
-        await nodeApi("test-task:package-config", { packageConfig: { "npm-run-all-test": { test: "OVERWRITTEN" } } })
-        assert(result() === "OVERWRITTEN")
-    })
+    const [major] = execSync("npm --version", { encoding: "utf8" }).trim().split(".")
 
-    it("Node API should address \"packageConfig\" option for multiple variables", async () => {
-        await nodeApi("test-task:package-config2", { packageConfig: { "npm-run-all-test": { test: "1", test2: "2", test3: "3" } } })
-        assert(result() === "1\n2\n3")
-    })
+    const supportsOverrides = major <= 6
 
-    describe("CLI commands should address \"--a:b=c\" style options", () => {
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:package-config", "--npm-run-all-test:test=OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
+    if (supportsOverrides) {
+        it("Node API should address \"packageConfig\" option", async () => {
+            await nodeApi("test-task:package-config", { packageConfig: { "npm-run-all-test": { test: "OVERWRITTEN" } } })
+            assert.equal(result(), "OVERWRITTEN")
         })
 
-        it("run-s command", async () => {
-            await runSeq(["test-task:package-config", "--npm-run-all-test:test=OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
+        it("Node API should address \"packageConfig\" option for multiple variables", async () => {
+            await nodeApi("test-task:package-config2", { packageConfig: { "npm-run-all-test": { test: "1", test2: "2", test3: "3" } } })
+            assert.equal(result(), "1\n2\n3")
         })
 
-        it("run-p command", async () => {
-            await runPar(["test-task:package-config", "--npm-run-all-test:test=OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
-        })
-    })
+        describe("CLI commands should address \"--a:b=c\" style options", () => {
+            it("npm-run-all command", async () => {
+                await runAll(["test-task:package-config", "--npm-run-all-test:test=OVERWRITTEN"])
+                assert.equal(result(), "OVERWRITTEN")
+            })
 
-    describe("CLI commands should address \"--a:b=c\" style options for multiple variables", () => {
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:package-config2", "--npm-run-all-test:test=1", "--npm-run-all-test:test2=2", "--npm-run-all-test:test3=3"])
-            assert(result() === "1\n2\n3")
-        })
+            it("run-s command", async () => {
+                await runSeq(["test-task:package-config", "--npm-run-all-test:test=OVERWRITTEN"])
+                assert.equal(result(), "OVERWRITTEN")
+            })
 
-        it("run-s command", async () => {
-            await runSeq(["test-task:package-config2", "--npm-run-all-test:test=1", "--npm-run-all-test:test2=2", "--npm-run-all-test:test3=3"])
-            assert(result() === "1\n2\n3")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:package-config2", "--npm-run-all-test:test=1", "--npm-run-all-test:test2=2", "--npm-run-all-test:test3=3"])
-            assert(result() === "1\n2\n3")
-        })
-    })
-
-    describe("CLI commands should address \"--a:b c\" style options", () => {
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
+            it("run-p command", async () => {
+                await runPar(["test-task:package-config", "--npm-run-all-test:test=OVERWRITTEN"])
+                assert.equal(result(), "OVERWRITTEN")
+            })
         })
 
-        it("run-s command", async () => {
-            await runSeq(["test-task:package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
+        describe("CLI commands should address \"--a:b=c\" style options for multiple variables", () => {
+            it("npm-run-all command", async () => {
+                await runAll(["test-task:package-config2", "--npm-run-all-test:test=1", "--npm-run-all-test:test2=2", "--npm-run-all-test:test3=3"])
+                assert.equal(result(), "1\n2\n3")
+            })
+
+            it("run-s command", async () => {
+                await runSeq(["test-task:package-config2", "--npm-run-all-test:test=1", "--npm-run-all-test:test2=2", "--npm-run-all-test:test3=3"])
+                assert.equal(result(), "1\n2\n3")
+            })
+
+            it("run-p command", async () => {
+                await runPar(["test-task:package-config2", "--npm-run-all-test:test=1", "--npm-run-all-test:test2=2", "--npm-run-all-test:test3=3"])
+                assert.equal(result(), "1\n2\n3")
+            })
         })
 
-        it("run-p command", async () => {
-            await runPar(["test-task:package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
-        })
-    })
+        describe("CLI commands should address \"--a:b c\" style options", () => {
+            it("npm-run-all command", async () => {
+                await runAll(["test-task:package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
+                assert.equal(result(), "OVERWRITTEN")
+            })
 
-    describe("CLI commands should transfar overriting nested commands.", () => {
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:nested-package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
+            it("run-s command", async () => {
+                await runSeq(["test-task:package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
+                assert.equal(result(), "OVERWRITTEN")
+            })
+
+            it("run-p command", async () => {
+                await runPar(["test-task:package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
+                assert.equal(result(), "OVERWRITTEN")
+            })
         })
 
-        it("run-s command", async () => {
-            await runSeq(["test-task:nested-package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
-        })
+        describe("CLI commands should transfar overriting nested commands.", () => {
+            it("npm-run-all command", async () => {
+                await runAll(["test-task:nested-package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
+                assert.equal(result(), "OVERWRITTEN")
+            })
 
-        it("run-p command", async () => {
-            await runPar(["test-task:nested-package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
+            it("run-s command", async () => {
+                await runSeq(["test-task:nested-package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
+                assert.equal(result(), "OVERWRITTEN")
+            })
+
+            it("run-p command", async () => {
+                await runPar(["test-task:nested-package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
+                assert.equal(result(), "OVERWRITTEN")
+            })
         })
-    })
+    }
 })


### PR DESCRIPTION
Fix tests for newer versions of node and npm, and also bump engines to the latest versions of node and npm. YMMV with older versions, though nothing specifically will break with this change other than a warning. 