### PR TITLE
docs: update minimum supported Node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install npm-run-all2 --save-dev
 $ yarn add npm-run-all2 --dev
 ```
 
-- It requires `Node@>=4`.
+- It requires `Node@>=14`. It may work on older versions of Node, but no guarantees are given.
 
 ## 📖 Usage
 


### PR DESCRIPTION
Since the `engines` field was updated to Node v14 in fc2957f4814848b55bc29b0a0a1def8bfadda18b, the README should be updated accordingly. I also mentioned running it on older versions of Node.js.

P. S. Thanks for maintaining this tool!