### PR TITLE
feat: move to read-package-json-fast

### DIFF
--- a/lib/read-package-json.js
+++ b/lib/read-package-json.js
@@ -23,7 +23,7 @@ const joinPath = require('path').join
  */
 module.exports = function readPackageJson () {
   const path = joinPath(process.cwd(), 'package.json')
-  return import('read-pkg').then(({ readPackage }) => readPackage(path)).then(body => ({
+  return import('read-package-json-fast').then(({ default: readPackage }) => readPackage(path)).then(body => ({
     taskList: Object.keys(body.scripts || {}),
     packageInfo: { path, body }
   }))

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "memorystream": "^0.3.1",
     "minimatch": "^9.0.0",
     "pidtree": "^0.6.0",
-    "read-pkg": "^8.0.0",
+    "read-package-json-fast": "^3.0.2",
     "shell-quote": "^1.7.3"
   },
   "devDependencies": {
@@ -42,8 +42,8 @@
     "jsdoc": "^4.0.0",
     "mocha": "^10.0.0",
     "p-queue": "^7.3.4",
-    "yarn": "^1.12.3",
-    "standard": "^17.1.0"
+    "standard": "^17.1.0",
+    "yarn": "^1.12.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This moves away from read-pkg to a much, much lighter package maintained by the npm team themselves (read-package-json-fast).

Saves us ~90k of install size and the time spent fetching the 15-20 dependencies read-pkg has
