### PR TITLE
Compatibility: npm, yarn and pnpm run scripts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -127,7 +127,7 @@ function parsePatterns (patternOrPatterns, args) {
 
       const patternList = pattern.split(' ')
       const doubleDashIndex = patternList.findIndex((item) => item === '--')
-      patternList.splice(doubleDashIndex, 1)
+      doubleDashIndex !== -1 && patternList.splice(doubleDashIndex, 1)
       pattern = patternList.join(' ')
 
       return pattern

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,8 +112,29 @@ function applyArguments (patterns, args) {
  * @returns {string[]} Parsed patterns.
  */
 function parsePatterns (patternOrPatterns, args) {
-  const patterns = toArray(patternOrPatterns)
-  const hasPlaceholder = patterns.some(pattern => ARGS_PATTERN.test(pattern))
+  let patterns = toArray(patternOrPatterns)
+
+  const isNPM = process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith('npm')
+
+  if (!isNPM) {
+    // yarn | pnpm
+    patterns = patterns.map((pattern) => {
+      const match = pattern.match(ARGS_PATTERN)
+
+      if (!match) {
+        return pattern
+      }
+
+      const patternList = pattern.split(' ')
+      const doubleDashIndex = patternList.findIndex((item) => item === '--')
+      patternList.splice(doubleDashIndex, 1)
+      pattern = patternList.join(' ')
+
+      return pattern
+    })
+  }
+
+  const hasPlaceholder = patterns.some((pattern) => pattern.match(ARGS_PATTERN))
 
   return hasPlaceholder ? applyArguments(patterns, args) : patterns
 }


### PR DESCRIPTION
This is a destructive change.

These commits purpose of this PR is to unify the usage of downstream calling because
npm (each version), yarn(v1.x, more see [https://github.com/yarnpkg/yarn/pull/4152](https://github.com/yarnpkg/yarn/pull/4152/files#diff-f00e7c78fa83a1316c2844a481cc2eeda7c7c2c4f958d39e9e457ddbc6b5c20fR113-R132)) and pnpm(v7+, more see [https://github.com/pnpm/pnpm/pull/4290](https://github.com/pnpm/pnpm/pull/4290/files#diff-c0a21f7925dd7f02d9af2aeb8297f31b6eb5a6bbe684bd7e2344a34f26bbd4e3R110-R141) [https://github.com/pnpm/pnpm/pull/3492](https://github.com/pnpm/pnpm/pull/3492/files#diff-15adee10b6a078ee14485dd0c4a317b792ce2c159dd8c489a80a6b523d19f434R72-R75), [https://github.com/pnpm/pnpm/pull/7370](https://github.com/pnpm/pnpm/pull/7370/files#diff-ce74bd4445509702768fb2bbfa7093c3bef3a76058e58e420baa3e78cbfa76b2R198-R200)) handle double-das differently.

Examples:
1. `npm` run scripts with args with the `npm run foo --  --args-go-here`.
2. `yarn` run scripts with args with the `yarn foo --  --args-go-here` or `yarn foo --args-go-here`
3. `pnpm` run scripts with args with the `pnpm foo --args-go-here`

After merged:
We can run `npm|yarn|pnpm [run] foo --  --args-go-here` only becase `npm-run-all2` will change `yarn` and `pnpm` script to `yarn|pnpm [run] foo --args-go-here` for compatibility. (Based on the use of NPM run-scripts!)

More details see: https://github.com/bcomnes/npm-run-all2/pull/143