### PR TITLE
Avoid passing config fields as flags for pnpm

### DIFF
--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -192,13 +192,15 @@ module.exports = function runTask (task, options) {
     }
 
     const isYarn = process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith('yarn')
+    const isPnpm = Boolean(process.env.PNPM_SCRIPT_SRC_DIR)
+    const isNpm = !isYarn && !isPnpm
 
     const spawnArgs = ['run']
 
     if (npmPathIsJs) {
       spawnArgs.unshift(npmPath)
     }
-    if (!isYarn) {
+    if (isNpm) {
       Array.prototype.push.apply(spawnArgs, options.prefixOptions)
     } else if (options.prefixOptions.indexOf('--silent') !== -1) {
       spawnArgs.push('--silent')


### PR DESCRIPTION
Matching the behavior with yarn, stop npm-run-all2 from passing fields in the package.json#config object as flags.

Note that this requires pnpm 9.1 or higher for `process.env.PNPM_SCRIPT_SRC_DIR` detection to work. 

Closes: https://github.com/bcomnes/npm-run-all2/issues/150

