### PR TITLE
Switch to JS-based `which` command

### DIFF
--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -12,11 +12,14 @@
 
 const fs = require('fs')
 const path = require('path')
+
+const ansiStylesPromise = import('ansi-styles')
 const parseArgs = require('shell-quote').parse
+const which = require('which')
+
 const createHeader = require('./create-header')
 const createPrefixTransform = require('./create-prefix-transform-stream')
 const spawn = require('./spawn')
-const ansiStylesPromise = import('ansi-styles')
 
 // ------------------------------------------------------------------------------
 // Helpers
@@ -185,7 +188,7 @@ module.exports = function runTask (task, options) {
       // Attempt to figure out whether we're running via pnpm
       const projectRoot = path.dirname(options.packageInfo.path)
       const hasPnpmLockfile = fs.existsSync(path.join(projectRoot, 'pnpm-lock.yaml'))
-      const { status: pnpmFound, output: pnpmWhichOutput } = await spawn('which', 'pnpm', { silent: true })
+      const { status: pnpmFound, output: pnpmWhichOutput } = await which('pnpm', { nothrow: true })
       if (hasPnpmLockfile && __dirname.split(path.delimiter).includes('.pnpm') && pnpmFound) {
         execPath = pnpmWhichOutput
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "minimatch": "^9.0.0",
     "pidtree": "^0.6.0",
     "read-package-json-fast": "^3.0.2",
-    "shell-quote": "^1.7.3"
+    "shell-quote": "^1.7.3",
+    "which": "^3.0.1"
   },
   "devDependencies": {
     "auto-changelog": "^2.2.0",


### PR DESCRIPTION
Version `3.0.1` of `which` is the latest that supports Node 14. Version 4 requires Node 16 and version 5 requires Node 18. So I'm sticking with `3.0.1` to avoid bumping the engines range in this PR.

`which` is built and maintained by `npm`: https://github.com/npm/node-which

And is tested across multiple environments: https://github.com/npm/node-which/blob/b8d11c791296a3baf44703352619621215189b0e/.github/workflows/ci.yml#L54-L65

Fixes #153