### PR TITLE
Publish with npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ concurrency: # prevent concurrent releases
 jobs:
   version_and_release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # for npm provenance
     steps:
       - uses: actions/checkout@v4
         with:

--- a/package.json
+++ b/package.json
@@ -83,5 +83,8 @@
       "lcovonly",
       "text"
     ]
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }


### PR DESCRIPTION
It'd be great if this package published with [npm provenance statements](https://docs.npmjs.com/generating-provenance-statements). Since publishing is already automated and uses GitHub Actions, these should be the only changes needed.