### PR TITLE
Add support for package.json5

### DIFF
--- a/lib/read-package-json.js
+++ b/lib/read-package-json.js
@@ -6,13 +6,15 @@
  */
 'use strict'
 
-const readPackage = require('read-package-json-fast')
-
 // ------------------------------------------------------------------------------
 // Requirements
 // ------------------------------------------------------------------------------
 
+const fs = require('fs')
 const joinPath = require('path').join
+const parseJson5 = require('json5').parse
+const parseJson = require('json-parse-even-better-errors')
+const normalizePackageData = require('npm-normalize-package-bin')
 
 // ------------------------------------------------------------------------------
 // Public Interface
@@ -24,9 +26,31 @@ const joinPath = require('path').join
  * @returns {object} package.json's information.
  */
 module.exports = function readPackageJson () {
-  const path = joinPath(process.cwd(), 'package.json')
-  return readPackage(path).then(body => ({
-    taskList: Object.keys(body.scripts || {}),
-    packageInfo: { path, body },
-  }))
+  try {
+    let path = joinPath(process.cwd(), 'package.json5')
+    let isJson5 = true
+
+    if (!fs.existsSync(path)) {
+      path = joinPath(process.cwd(), 'package.json')
+      isJson5 = false
+    }
+
+    const rawPkg = fs.readFileSync(path, 'utf8')
+    let body = null
+
+    if (isJson5) {
+      // Read package.json5
+      body = parseJson5(rawPkg)
+    } else {
+      body = parseJson(rawPkg)
+    }
+
+    normalizePackageData(body)
+    return Promise.resolve({
+      taskList: Object.keys(body.scripts || {}),
+      packageInfo: { path, body },
+    })
+  } catch (err) {
+    return Promise.reject(err)
+  }
 }

--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
   "dependencies": {
     "ansi-styles": "^6.2.1",
     "cross-spawn": "^7.0.3",
+    "json-parse-even-better-errors": "^4.0.0",
+    "json5": "^2.2.3",
     "memorystream": "^0.3.1",
     "minimatch": "^9.0.0",
+    "npm-normalize-package-bin": "^4.0.0",
     "pidtree": "^0.6.0",
-    "read-package-json-fast": "^4.0.0",
     "shell-quote": "^1.7.3",
     "which": "^5.0.0"
   },

--- a/test-workspace/json5/package.json5
+++ b/test-workspace/json5/package.json5
@@ -1,0 +1,22 @@
+{
+  /*
+   * Test comment
+   */
+
+  name: "npm-run-all-json5-test",
+  version: "0.0.0",
+  private: true,
+  description: "",
+  engines: {
+    node: ">=4",
+  },
+  config: {
+    test: "OK",
+  },
+  repository: {
+    type: "git",
+    url: "https://github.com/mysticatea/npm-run-all.git",
+  },
+  author: "Toru Nagashima",
+  license: "MIT",
+}

--- a/test/json5.js
+++ b/test/json5.js
@@ -1,0 +1,32 @@
+/**
+ * @author Toru Nagashima
+ * @copyright 2016 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const assert = require('assert').strict
+const readPackageJson = require('../lib/read-package-json')
+
+// ------------------------------------------------------------------------------
+// Test
+// ------------------------------------------------------------------------------
+
+describe('[json5]', () => {
+  before(() => process.chdir('test-workspace/json5'))
+  after(() => process.chdir('../..'))
+
+  it('should read package.json5 when available', () =>
+    readPackageJson().then((result) =>
+      assert(result.packageInfo.path.endsWith('/package.json5'))
+    ))
+
+  it('should parse package.json5', () =>
+    readPackageJson().then((result) =>
+      assert(result.packageInfo.body.name === 'npm-run-all-json5-test')
+    ))
+})


### PR DESCRIPTION
Similar to https://github.com/mysticatea/npm-run-all/pull/266

## Notes

### Removed `read-package-json-fast`

`read-package-json-fast` doesn't support json5, and since it is an official NPM tool, it is probably not going to.
Thankfully, everything the package does that we care about is fairly simple.

Mostly, [it uses the `json-parse-even-better-errors` and `npm-normalize-package-bin` packages](https://github.com/npm/read-package-json-fast/blob/v4.0.0/lib/index.js#L2-L3).
I am now using these packages directly instead of `read-package-json-fast`.
None of the things `read-package-json-fast` does impact `npm-run-all2`.

### Consistency

The return value of the `readPackageJson` function is still a promise even though the function is now entirely sync.
We could use `fs/promise`, but nothing else does yet.
This was all for consistency, but let me know if you would like to change it.

### Tests

Tests are the same as `npm-run-all` so I will paste my note from there:

I have tried my best at writing tests for this change.
I don't think it is perfectly in line with the style of your other tests, but this was the simplest way I could see to test it.
If you have other ideas for tests, feel free to give guidance or change my tests when merging.