### PR TITLE
Raise engine floor to >= Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,7 @@ on:
         required: true
 
 env:
-  NODE_VERSION: 'lts/*'
-  FORCE_COLOR: 2
+  FORCE_COLOR: 1
 
 concurrency: # prevent concurrent releases
   group: npm-bump
@@ -23,10 +22,10 @@ jobs:
         with:
           # fetch full history so things like auto-changelog work properly
           fetch-depth: 0
-      - name: Use Node.js ${{ env.NODE_VERSION }}
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
           # setting a registry enables the NODE_AUTH_TOKEN env variable where we can set an npm token.  REQUIRED
           registry-url: 'https://registry.npmjs.org'
       - run: npm i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js lts/*
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version-file: package.json
       - run: npm i
       - run: npm run check
 
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node: ['lts/*', 18]
+        node: ['20', 'lts/*', '23']
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "npm-run-all2",
   "version": "7.0.2",
-  "description": "A CLI tool to run multiple npm-scripts in parallel or sequential. (Maintainence fork)",
+  "description": "A CLI tool to run multiple npm-scripts in parallel or sequential. (Maintenance fork)",
   "bin": {
     "run-p": "bin/run-p/index.js",
     "run-s": "bin/run-s/index.js",
@@ -10,8 +10,8 @@
   },
   "main": "lib/index.js",
   "engines": {
-    "node": "^18.17.0 || >=20.5.0",
-    "npm": ">= 9"
+    "node": ">=20.5.0",
+    "npm": ">= 10"
   },
   "scripts": {
     "clean": "rm -rf coverage jsdoc \"test-workspace/{build,test.txt}\"",


### PR DESCRIPTION
BREAKING CHANGE: Node 18 EOL. Please update to Node 20 or newer (preferably 22). Running on older versions of node will stop working eventually.