### PR TITLE
Use a more specific engine range within 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "lib/index.js",
   "engines": {
-    "node": ">=20.5.0",
+    "node": "^20.5.0 || >=22.0.0",
     "npm": ">= 10"
   },
   "scripts": {


### PR DESCRIPTION
Counting this as a bugfix to the major version we just did.