### PR TITLE
Replace `minimatch` with `picomatch`

### DIFF
--- a/lib/match-tasks.js
+++ b/lib/match-tasks.js
@@ -10,8 +10,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const { minimatch } = require('minimatch')
-const Minimatch = minimatch.Minimatch
+const picomatch = require('picomatch')
 
 // ------------------------------------------------------------------------------
 // Helpers
@@ -21,7 +20,7 @@ const COLON_OR_SLASH = /[:/]/g
 const CONVERT_MAP = { ':': '/', '/': ':' }
 
 /**
- * Swaps ":" and "/", in order to use ":" as the separator in minimatch.
+ * Swaps ":" and "/", in order to use ":" as the separator in picomatch.
  *
  * @param {string} s - A text to swap.
  * @returns {string} The text which was swapped.
@@ -44,8 +43,7 @@ function createFilter (pattern) {
   const spacePos = trimmed.indexOf(' ')
   const task = spacePos < 0 ? trimmed : trimmed.slice(0, spacePos)
   const args = spacePos < 0 ? '' : trimmed.slice(spacePos)
-  const matcher = new Minimatch(swapColonAndSlash(task), { nonegate: true })
-  const match = matcher.match.bind(matcher)
+  const match = picomatch(swapColonAndSlash(task), { nonegate: true })
 
   return { match, task, args }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ansi-styles": "^6.2.1",
     "cross-spawn": "^7.0.6",
     "memorystream": "^0.3.1",
-    "minimatch": "^10.0.1",
+    "picomatch": "^4.0.2",
     "pidtree": "^0.6.0",
     "read-package-json-fast": "^4.0.0",
     "shell-quote": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "npm-run-all2",
+  "type": "commonjs",
   "version": "8.0.1",
   "description": "A CLI tool to run multiple npm-scripts in parallel or sequential. (Maintenance fork)",
   "bin": {


### PR DESCRIPTION
This PR replaces `minimatch` with `picomatch` as asked about in #171.

`picomatch` is at worst [twice as fast](https://github.com/micromatch/picomatch#benchmarks), and at best magnitudes faster than `minimatch`, while also being 1/4th the size on disk.