### PR TITLE
Revert "replace minimatch with picomatch"

### DIFF
--- a/lib/match-tasks.js
+++ b/lib/match-tasks.js
@@ -10,7 +10,8 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const picomatch = require('picomatch')
+const { minimatch } = require('minimatch')
+const Minimatch = minimatch.Minimatch
 
 // ------------------------------------------------------------------------------
 // Helpers
@@ -20,7 +21,7 @@ const COLON_OR_SLASH = /[:/]/g
 const CONVERT_MAP = { ':': '/', '/': ':' }
 
 /**
- * Swaps ":" and "/", in order to use ":" as the separator in picomatch.
+ * Swaps ":" and "/", in order to use ":" as the separator in minimatch.
  *
  * @param {string} s - A text to swap.
  * @returns {string} The text which was swapped.
@@ -43,7 +44,8 @@ function createFilter (pattern) {
   const spacePos = trimmed.indexOf(' ')
   const task = spacePos < 0 ? trimmed : trimmed.slice(0, spacePos)
   const args = spacePos < 0 ? '' : trimmed.slice(spacePos)
-  const match = picomatch(swapColonAndSlash(task), { nonegate: true })
+  const matcher = new Minimatch(swapColonAndSlash(task), { nonegate: true })
+  const match = matcher.match.bind(matcher)
 
   return { match, task, args }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ansi-styles": "^6.2.1",
     "cross-spawn": "^7.0.6",
     "memorystream": "^0.3.1",
-    "picomatch": "^4.0.2",
+    "minimatch": "^10.0.1",
     "pidtree": "^0.6.0",
     "read-package-json-fast": "^4.0.0",
     "shell-quote": "^1.7.3",


### PR DESCRIPTION
Reverts switch to picomatch until we can get the issues with `**` worked out. 



- Closes https://github.com/bcomnes/npm-run-all2/issues/174
- Closes https://github.com/bcomnes/npm-run-all2/issues/173

