### PR TITLE
fix: `foo:**` matching regression

### DIFF
--- a/lib/match-tasks.js
+++ b/lib/match-tasks.js
@@ -43,7 +43,10 @@ function createFilter (pattern) {
   const spacePos = trimmed.indexOf(' ')
   const task = spacePos < 0 ? trimmed : trimmed.slice(0, spacePos)
   const args = spacePos < 0 ? '' : trimmed.slice(spacePos)
-  const match = picomatch(swapColonAndSlash(task), { nonegate: true })
+  const match = picomatch(swapColonAndSlash(task), {
+    nonegate: true,
+    strictSlashes: true,
+  })
 
   return { match, task, args }
 }

--- a/test/pattern.js
+++ b/test/pattern.js
@@ -50,6 +50,24 @@ describe('[pattern] it should run matched tasks if glob like patterns are given.
     })
   })
 
+  describe('"test-task:append:**" to "test-task:append:a", "test-task:append:a:c", "test-task:append:a:d", and "test-task:append:b"', () => {
+    it('Node API', async () => {
+      await nodeApi('test-task:append:**')
+      assert(result() === 'aaacacadadbb')
+    })
+
+    it('npm-run-all command', async () => {
+      await runAll(['test-task:append:**'])
+      assert(result() === 'aaacacadadbb')
+    })
+
+    it('run-s command', async () => {
+      await runSeq(['test-task:append:**'])
+      assert(result() === 'aaacacadadbb')
+    })
+  })
+
+  // should act same way as section above
   describe('"test-task:append:**:*" to "test-task:append:a", "test-task:append:a:c", "test-task:append:a:d", and "test-task:append:b"', () => {
     it('Node API', async () => {
       await nodeApi('test-task:append:**:*')


### PR DESCRIPTION
This case did not have tests and has different default behavior across the various pattern matching libraries.

Fixed by adding `strictSlashes: true` to options.

![Image](https://github.com/user-attachments/assets/0f58df76-a401-4a21-a187-aa7490da6df3)