### PR TITLE
Improve npm lifecycles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
           # setting a registry enables the NODE_AUTH_TOKEN env variable where we can set an npm token.  REQUIRED
           registry-url: 'https://registry.npmjs.org'
       - run: npm i
+      - run: npm test
       - run: git status # getting odd dirty repo errors during version debug info
       - run: git diff
       - name: npm version && npm publish

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "test": "node ./bin/run-s/index.js check test-mocha",
     "watch": "mocha --timeout 120000 --watch --growl",
     "version": "auto-changelog -p --template keepachangelog auto-changelog --breaking-pattern 'BREAKING CHANGE:' && git add CHANGELOG.md",
-    "preversion": "npm test",
-    "postversion": "git push --follow-tags && gh-release -y"
+    "prepublishOnly": "git push --follow-tags && gh-release -y"
   },
   "dependencies": {
     "ansi-styles": "^6.2.1",


### PR DESCRIPTION
- Remove npm test from preversion. Collapsing lifecycles is unexpected.
- Move postversion to prepublishOnly. Pushing to github is publishing, not versioning!