### PR TITLE
refactor: use the opposite operator (<) instead

### DIFF
--- a/lib/esm.mjs
+++ b/lib/esm.mjs
@@ -252,7 +252,7 @@ export default function npmRunAll (patternOrPatterns, options) {
     if (taskList != null && Array.isArray(taskList) === false) {
       throw new Error('Invalid options.taskList')
     }
-    if (typeof maxParallel !== 'number' || !(maxParallel >= 0)) {
+    if (typeof maxParallel !== 'number' || maxParallel < 0) {
       throw new Error('Invalid options.maxParallel')
     }
     if (!parallel && aggregateOutput) {


### PR DESCRIPTION
use the opposite operator (<) instead for better readability