### PR TITLE
refactor: use an object spread instead of Object.assign & .apply

### DIFF
--- a/bin/common/parse-cli-args.js
+++ b/bin/common/parse-cli-args.js
@@ -58,10 +58,11 @@ function createPackageConfig () {
  * @returns {void}
  */
 function addGroup (groups, initialValues) {
-  groups.push(Object.assign(
-    { parallel: false, patterns: [] },
-    initialValues || {}
-  ))
+  groups.push({
+    parallel: false,
+    patterns: [],
+    ...(initialValues || {})
+  })
 }
 
 /**

--- a/lib/run-tasks.js
+++ b/lib/run-tasks.js
@@ -139,7 +139,7 @@ export default function runTasks (tasks, options) {
       }
 
       const originalOutputStream = options.stdout
-      const optionsClone = Object.assign({}, options)
+      const optionsClone = { ...options }
       const writer = new MemoryStream(null, {
         readable: false,
       })

--- a/test-workspace/tasks/echo.cjs
+++ b/test-workspace/tasks/echo.cjs
@@ -16,7 +16,7 @@ function flow () {
 
   head()
   setTimeout(() => {
-    flow.apply(null, rest)
+    flow(...rest)
   }, 33)
 }
 


### PR DESCRIPTION
use an object spread instead of Object.assign & .apply to make it more concise and readable