### PR TITLE
docs: clarify glob pattern execution order guarantee

### DIFF
--- a/docs/npm-run-all.md
+++ b/docs/npm-run-all.md
@@ -135,6 +135,15 @@ If we use a globstar `**`, runs both sub scripts and sub-sub scripts.
 
 `npm-run-all` reads the actual npm-script list from `package.json` in the current directory, then filters the scripts by glob-like patterns, then runs those.
 
+#### Script execution order with glob patterns
+
+When using glob patterns with `--sequential` / `run-s`, matched scripts are run in the order they are defined in `package.json`. This ordering is guaranteed by the [ECMAScript specification](https://tc39.es/ecma262/#sec-ordinaryownpropertykeys), which requires that string-keyed properties are iterated in chronological order of creation (i.e., the order they appear in the file).
+
+**Note:** Some tools (formatters, sorters) may rewrite `package.json` with scripts sorted alphabetically. If strict execution order matters, consider:
+
+- Prefixing script names with numbers (e.g. `build:1:html`, `build:2:js`) so they sort correctly even after an alphabetical reorder.
+- Using explicit script names instead of glob patterns to guarantee order regardless of `package.json` layout.
+
 ### Run with arguments
 
 We can enclose a script name or a pattern in quotes to use arguments.

--- a/docs/npm-run-all.md
+++ b/docs/npm-run-all.md
@@ -137,7 +137,7 @@ If we use a globstar `**`, runs both sub scripts and sub-sub scripts.
 
 #### Script execution order with glob patterns
 
-When using glob patterns with `--sequential` / `run-s`, matched scripts are run in the order they are defined in `package.json`. This ordering is guaranteed by the [ECMAScript specification](https://tc39.es/ecma262/#sec-ordinaryownpropertykeys), which requires that string-keyed properties are iterated in chronological order of creation (i.e., the order they appear in the file).
+When using glob patterns with `--sequential` / `run-s`, matched scripts are run in the order they are defined in `package.json`. This ordering is guaranteed by the [ECMAScript specification](https://tc39.es/ecma262/#sec-ordinaryownpropertykeys), which requires that string-keyed properties are iterated in chronological order of creation (i.e., the order they appear in the file). Note: the spec treats pure-integer keys (e.g. `"1"`, `"10"`) as array indices and sorts them numerically before other keys — avoid using bare numbers as script names if order matters.
 
 **Note:** Some tools (formatters, sorters) may rewrite `package.json` with scripts sorted alphabetically. If strict execution order matters, consider:
 

--- a/docs/run-s.md
+++ b/docs/run-s.md
@@ -92,7 +92,7 @@ If we use a globstar `**`, runs both sub scripts and sub-sub scripts.
 
 #### Script execution order with glob patterns
 
-When using glob patterns with `run-s`, matched scripts are run in the order they are defined in `package.json`. This ordering is guaranteed by the [ECMAScript specification](https://tc39.es/ecma262/#sec-ordinaryownpropertykeys), which requires that string-keyed properties are iterated in chronological order of creation (i.e., the order they appear in the file).
+When using glob patterns with `run-s`, matched scripts are run in the order they are defined in `package.json`. This ordering is guaranteed by the [ECMAScript specification](https://tc39.es/ecma262/#sec-ordinaryownpropertykeys), which requires that string-keyed properties are iterated in chronological order of creation (i.e., the order they appear in the file). Note: the spec treats pure-integer keys (e.g. `"1"`, `"10"`) as array indices and sorts them numerically before other keys — avoid using bare numbers as script names if order matters.
 
 **Note:** Some tools (formatters, sorters) may rewrite `package.json` with scripts sorted alphabetically. If strict execution order matters, consider:
 

--- a/docs/run-s.md
+++ b/docs/run-s.md
@@ -90,6 +90,15 @@ If we use a globstar `**`, runs both sub scripts and sub-sub scripts.
 
 `run-s` reads the actual npm-script list from `package.json` in the current directory, then filters the scripts by glob-like patterns, then runs those.
 
+#### Script execution order with glob patterns
+
+When using glob patterns with `run-s`, matched scripts are run in the order they are defined in `package.json`. This ordering is guaranteed by the [ECMAScript specification](https://tc39.es/ecma262/#sec-ordinaryownpropertykeys), which requires that string-keyed properties are iterated in chronological order of creation (i.e., the order they appear in the file).
+
+**Note:** Some tools (formatters, sorters) may rewrite `package.json` with scripts sorted alphabetically. If strict execution order matters, consider:
+
+- Prefixing script names with numbers (e.g. `build:1:html`, `build:2:js`) so they sort correctly even after an alphabetical reorder.
+- Using explicit script names instead of glob patterns to guarantee order regardless of `package.json` layout.
+
 ### Run with arguments
 
 We can enclose a script name or a pattern in quotes to use arguments.


### PR DESCRIPTION
Closes #167. Documents that scripts matched by glob patterns are run in the order they appear in package.json, per the ECMAScript spec, and notes the risk of tools that alphabetically sort package.json scripts.