### PR TITLE
Remove redundant build call from prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build": "npm run build:declaration",
     "build:declaration": "tsc -p declaration.tsconfig.json",
     "clean:declarations-lib": "find lib -type f -name '*.d.*' -delete",
-    "prepublishOnly": "npm run build && releasearoni",
+    "prepublishOnly": "releasearoni",
     "postpublish": "npm run clean"
   },
   "dependencies": {


### PR DESCRIPTION
releasearoni automatically runs `npm run build` if a build script exists, so calling it explicitly beforehand causes tsc to run twice. The second run fails with TS5055 because the .d.ts files from the first run are now included in the input glob (lib/**/*) and would be overwritten.