### PR TITLE
Add -x / --node-run flag to bypass the package manager

### DIFF
--- a/bin/common/parse-cli-args.js
+++ b/bin/common/parse-cli-args.js
@@ -12,7 +12,7 @@
 const OVERWRITE_OPTION = /^--([^:]+?):([^=]+?)(?:=(.+))?$/
 const CONFIG_OPTION = /^--([^=]+?)(?:=(.+))$/
 const PACKAGE_CONFIG_PATTERN = /^npm_package_config_(.+)$/
-const CONCAT_OPTIONS = /^-[clnprs]+$/
+const CONCAT_OPTIONS = /^-[clnprsx]+$/
 
 /**
  * @typedef {Record<string, string>} ConfigMap
@@ -114,6 +114,8 @@ class ArgumentSet {
     this.silent = process.env['npm_config_loglevel'] === 'silent'
     /** @type {boolean} */
     this.singleMode = Boolean(options?.singleMode)
+    /** @type {boolean} */
+    this.nodeRun = false
 
     addGroup(this.groups, initialValues)
   }
@@ -223,6 +225,11 @@ function parseCLIArgsCore (set, args) {
 
       case '--npm-path':
         set.npmPath = args[++i] || null
+        break
+
+      case '-x':
+      case '--node-run':
+        set.nodeRun = true
         break
 
       default: {

--- a/bin/npm-run-all/main.js
+++ b/bin/npm-run-all/main.js
@@ -55,6 +55,7 @@ export default function npmRunAll (args, stdout, stderr) {
             race: group.parallel && argv.race,
             npmPath: argv.npmPath,
             aggregateOutput: group.parallel && argv.aggregateOutput,
+            nodeRun: argv.nodeRun,
           }
         ))
       },

--- a/bin/run-p/main.js
+++ b/bin/run-p/main.js
@@ -55,6 +55,7 @@ export default function npmRunAll (args, stdout, stderr) {
         race: argv.race,
         npmPath: argv.npmPath,
         aggregateOutput: argv.aggregateOutput,
+        nodeRun: argv.nodeRun,
       }
     )
 

--- a/bin/run-s/main.js
+++ b/bin/run-s/main.js
@@ -52,6 +52,7 @@ export default function npmRunAll (args, stdout, stderr) {
         silent: argv.silent,
         arguments: argv.rest,
         npmPath: argv.npmPath,
+        nodeRun: argv.nodeRun,
       }
     )
 

--- a/docs/npm-run-all.md
+++ b/docs/npm-run-all.md
@@ -42,6 +42,14 @@ Options:
                                     'npm run foo && npm run bar'.
                                '--serial' is a synonym of '--sequential'.
     --silent   - - - - - - - - Set 'silent' to the log level of npm.
+    -x, --node-run   - - - - - Use `node --run` to execute scripts instead of
+                               the package manager. This is faster but has
+                               intentional limitations: no pre/post lifecycle
+                               hooks, no npm_* environment variables, and no
+                               automatic PATH injection for local binaries.
+                               Can also be enabled project-wide by setting
+                               `"npm-run-all2": { "nodeRun": true }` in
+                               package.json.
 
 Examples:
     $ npm-run-all --serial clean lint build:**

--- a/docs/npm-run-all.md
+++ b/docs/npm-run-all.md
@@ -43,10 +43,11 @@ Options:
                                '--serial' is a synonym of '--sequential'.
     --silent   - - - - - - - - Set 'silent' to the log level of npm.
     -x, --node-run   - - - - - Use `node --run` to execute scripts instead of
-                               the package manager. This is faster but has
-                               intentional limitations: no pre/post lifecycle
-                               hooks, no npm_* environment variables, and no
-                               automatic PATH injection for local binaries.
+                               the package manager. This is faster but
+                               intentionally omits: pre/post lifecycle hooks
+                               and npm_* environment variables. node_modules/.bin
+                               is still added to PATH. Sets NODE_RUN_SCRIPT_NAME
+                               and NODE_RUN_PACKAGE_JSON_PATH instead.
                                Can also be enabled project-wide by setting
                                `"npm-run-all2": { "nodeRun": true }` in
                                package.json.

--- a/docs/run-p.md
+++ b/docs/run-p.md
@@ -37,6 +37,14 @@ Options:
     -r, --race   - - - - - - - Set the flag to kill all tasks when a task
                                finished with zero.
     -s, --silent   - - - - - - Set 'silent' to the log level of npm.
+    -x, --node-run   - - - - - Use `node --run` to execute scripts instead of
+                               the package manager. This is faster but has
+                               intentional limitations: no pre/post lifecycle
+                               hooks, no npm_* environment variables, and no
+                               automatic PATH injection for local binaries.
+                               Can also be enabled project-wide by setting
+                               `"npm-run-all2": { "nodeRun": true }` in
+                               package.json.
 
     Shorthand aliases can be combined.
     For example, '-clns' equals to '-c -l -n -s'.

--- a/docs/run-p.md
+++ b/docs/run-p.md
@@ -38,10 +38,11 @@ Options:
                                finished with zero.
     -s, --silent   - - - - - - Set 'silent' to the log level of npm.
     -x, --node-run   - - - - - Use `node --run` to execute scripts instead of
-                               the package manager. This is faster but has
-                               intentional limitations: no pre/post lifecycle
-                               hooks, no npm_* environment variables, and no
-                               automatic PATH injection for local binaries.
+                               the package manager. This is faster but
+                               intentionally omits: pre/post lifecycle hooks
+                               and npm_* environment variables. node_modules/.bin
+                               is still added to PATH. Sets NODE_RUN_SCRIPT_NAME
+                               and NODE_RUN_PACKAGE_JSON_PATH instead.
                                Can also be enabled project-wide by setting
                                `"npm-run-all2": { "nodeRun": true }` in
                                package.json.

--- a/docs/run-s.md
+++ b/docs/run-s.md
@@ -31,6 +31,14 @@ Options:
     -n, --print-name   - - - - Set the flag to print the task name before
                                running each task.
     -s, --silent   - - - - - - Set 'silent' to the log level of npm.
+    -x, --node-run   - - - - - Use `node --run` to execute scripts instead of
+                               the package manager. This is faster but has
+                               intentional limitations: no pre/post lifecycle
+                               hooks, no npm_* environment variables, and no
+                               automatic PATH injection for local binaries.
+                               Can also be enabled project-wide by setting
+                               `"npm-run-all2": { "nodeRun": true }` in
+                               package.json.
 
     Shorthand aliases can be combined.
     For example, '-clns' equals to '-c -l -n -s'.

--- a/docs/run-s.md
+++ b/docs/run-s.md
@@ -32,10 +32,11 @@ Options:
                                running each task.
     -s, --silent   - - - - - - Set 'silent' to the log level of npm.
     -x, --node-run   - - - - - Use `node --run` to execute scripts instead of
-                               the package manager. This is faster but has
-                               intentional limitations: no pre/post lifecycle
-                               hooks, no npm_* environment variables, and no
-                               automatic PATH injection for local binaries.
+                               the package manager. This is faster but
+                               intentionally omits: pre/post lifecycle hooks
+                               and npm_* environment variables. node_modules/.bin
+                               is still added to PATH. Sets NODE_RUN_SCRIPT_NAME
+                               and NODE_RUN_PACKAGE_JSON_PATH instead.
                                Can also be enabled project-wide by setting
                                `"npm-run-all2": { "nodeRun": true }` in
                                package.json.

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,7 @@
  * @property {string | null} [npmPath] - Path to npm.
  * @property {boolean} [race] - Abort other tasks after one parallel task succeeds.
  * @property {boolean} [aggregateOutput] - Buffer each task's stdout and write it after task completion.
+ * @property {boolean} [nodeRun] - Use `node --run` instead of the package manager to run scripts.
  *
  * @typedef NpmRunAllResult
  * @property {string} name - Task name.
@@ -233,6 +234,7 @@ export default function npmRunAll (patternOrPatterns, options) {
   const maxParallel = parallel ? ((options && options.maxParallel) || 0) : 1
   const aggregateOutput = Boolean(options && options.aggregateOutput)
   const npmPath = options && options.npmPath
+  const nodeRun = Boolean(options && options.nodeRun)
   try {
     const patterns = parsePatterns(patternOrPatterns, args)
     if (patterns.length === 0) {
@@ -264,6 +266,9 @@ export default function npmRunAll (patternOrPatterns, options) {
       const tasks = matchTasks(x.taskList, patterns)
       const labelWidth = tasks.reduce(maxLength, 0)
 
+      const pkgConfig = x.packageInfo?.body?.['npm-run-all2']
+      const effectiveNodeRun = nodeRun || Boolean(pkgConfig && typeof pkgConfig === 'object' && 'nodeRun' in pkgConfig && pkgConfig['nodeRun'])
+
       return runTasks(tasks, {
         stdin,
         stdout,
@@ -282,6 +287,7 @@ export default function npmRunAll (patternOrPatterns, options) {
         maxParallel,
         npmPath,
         aggregateOutput,
+        nodeRun: effectiveNodeRun,
       })
     })()
   } catch (err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -267,7 +267,7 @@ export default function npmRunAll (patternOrPatterns, options) {
       const labelWidth = tasks.reduce(maxLength, 0)
 
       const pkgConfig = x.packageInfo?.body?.['npm-run-all2']
-      const effectiveNodeRun = nodeRun || Boolean(pkgConfig && typeof pkgConfig === 'object' && 'nodeRun' in pkgConfig && pkgConfig['nodeRun'])
+      const effectiveNodeRun = nodeRun || (pkgConfig != null && typeof pkgConfig === 'object' && pkgConfig['nodeRun'] === true)
 
       return runTasks(tasks, {
         stdin,

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,9 @@
  * @typedef NpmRunAllResult
  * @property {string} name - Task name.
  * @property {number | undefined} code - Exit code, or undefined if the task was aborted before completion.
+ *
+ * @typedef PackageJsonConfig
+ * @property {boolean} [nodeRun] - Use `node --run` instead of the package manager to run scripts.
  */
 
 // ------------------------------------------------------------------------------
@@ -204,6 +207,25 @@ function maxLength (length, name) {
   return Math.max(name.length, length)
 }
 
+/**
+ * Reads and validates the `"npm-run-all2"` config object from a package.json body.
+ *
+ * @param {PackageJson | undefined} body - The package.json body.
+ * @returns {PackageJsonConfig} Validated config (unknown keys and non-boolean values are ignored).
+ */
+function readPackageConfig (body) {
+  const raw = body?.['npm-run-all2']
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return {}
+  }
+  /** @type {PackageJsonConfig} */
+  const config = {}
+  if ('nodeRun' in raw && /** @type {any} */ (raw).nodeRun === true) {
+    config.nodeRun = true
+  }
+  return config
+}
+
 // ------------------------------------------------------------------------------
 // Public Interface
 // ------------------------------------------------------------------------------
@@ -266,8 +288,8 @@ export default function npmRunAll (patternOrPatterns, options) {
       const tasks = matchTasks(x.taskList, patterns)
       const labelWidth = tasks.reduce(maxLength, 0)
 
-      const pkgConfig = x.packageInfo?.body?.['npm-run-all2']
-      const effectiveNodeRun = nodeRun || (pkgConfig != null && typeof pkgConfig === 'object' && pkgConfig['nodeRun'] === true)
+      const pkgConfig = readPackageConfig(x.packageInfo?.body)
+      const effectiveNodeRun = nodeRun || pkgConfig.nodeRun === true
 
       return runTasks(tasks, {
         stdin,

--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -188,7 +188,9 @@ export default function runTask (task, options) {
     if (options.nodeRun) {
       const taskParts = parseArgs(task).map(cleanTaskArg)
       const scriptName = taskParts[0] ?? task
-      const scriptArgs = taskParts.slice(1).filter(a => a !== '--')
+      const restParts = taskParts.slice(1)
+      const separatorIdx = restParts.indexOf('--')
+      const scriptArgs = separatorIdx === -1 ? restParts : restParts.slice(separatorIdx + 1)
       finalExecPath = process.execPath
       finalSpawnArgs = scriptArgs.length > 0
         ? ['--run', scriptName, '--', ...scriptArgs]

--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -22,6 +22,7 @@
  * @property {boolean} printName - Print task names before running each task.
  * @property {PackageInfo | null} packageInfo - package.json metadata.
  * @property {string | null | undefined} [npmPath] - Path to npm.
+ * @property {boolean} [nodeRun] - Use `node --run` instead of the package manager to run scripts.
  *
  * @typedef RunTaskResult
  * @property {string} task - Task name.
@@ -181,55 +182,71 @@ export default function runTask (task, options) {
     }
 
     // Execute.
-    let npmPath = options.npmPath
-    if (!npmPath && process.env['npm_execpath']) {
-      const npmExecPath = process.env['npm_execpath']
-      const basename = path.basename(npmExecPath)
-      let newBasename = basename
-      if (basename.startsWith('npx')) {
-        newBasename = basename.replace('npx', 'npm')
-      } else if (basename.startsWith('pnpx')) {
-        newBasename = basename.replace('pnpx', 'pnpm')
+    let finalExecPath
+    let finalSpawnArgs
+
+    if (options.nodeRun) {
+      const taskParts = parseArgs(task).map(cleanTaskArg)
+      const scriptName = taskParts[0] ?? task
+      const scriptArgs = taskParts.slice(1).filter(a => a !== '--')
+      finalExecPath = process.execPath
+      finalSpawnArgs = scriptArgs.length > 0
+        ? ['--run', scriptName, '--', ...scriptArgs]
+        : ['--run', scriptName]
+    } else {
+      let npmPath = options.npmPath
+      if (!npmPath && process.env['npm_execpath']) {
+        const npmExecPath = process.env['npm_execpath']
+        const basename = path.basename(npmExecPath)
+        let newBasename = basename
+        if (basename.startsWith('npx')) {
+          newBasename = basename.replace('npx', 'npm')
+        } else if (basename.startsWith('pnpx')) {
+          newBasename = basename.replace('pnpx', 'pnpm')
+        }
+
+        npmPath = newBasename !== basename
+          ? path.join(path.dirname(npmExecPath), newBasename)
+          : npmExecPath
       }
 
-      npmPath = newBasename !== basename
-        ? path.join(path.dirname(npmExecPath), newBasename)
-        : npmExecPath
-    }
+      const npmPathIsJs = typeof npmPath === 'string' && /\.(c|m)?js/.test(path.extname(npmPath))
+      let execPath = (npmPathIsJs ? process.execPath : npmPath || 'npm')
 
-    const npmPathIsJs = typeof npmPath === 'string' && /\.(c|m)?js/.test(path.extname(npmPath))
-    let execPath = (npmPathIsJs ? process.execPath : npmPath || 'npm')
-
-    if (!npmPath && !process.env['npm_execpath'] && options.packageInfo != null) {
-      // When a script is being run via pnpm, npmPath and npm_execpath will be null or undefined
-      // Attempt to figure out whether we're running via pnpm
-      const projectRoot = path.dirname(options.packageInfo.path)
-      const hasPnpmLockfile = fs.existsSync(path.join(projectRoot, 'pnpm-lock.yaml'))
-      const whichPnpmResults = await which('pnpm', { nothrow: true })
-      const pnpmFound = whichPnpmResults?.status
-      const pnpmWhichOutput = whichPnpmResults?.output
-      if (hasPnpmLockfile && import.meta.dirname.split(path.sep).includes('.pnpm') && pnpmFound && pnpmWhichOutput) {
-        execPath = pnpmWhichOutput
+      if (!npmPath && !process.env['npm_execpath'] && options.packageInfo != null) {
+        // When a script is being run via pnpm, npmPath and npm_execpath will be null or undefined
+        // Attempt to figure out whether we're running via pnpm
+        const projectRoot = path.dirname(options.packageInfo.path)
+        const hasPnpmLockfile = fs.existsSync(path.join(projectRoot, 'pnpm-lock.yaml'))
+        const whichPnpmResults = await which('pnpm', { nothrow: true })
+        const pnpmFound = whichPnpmResults?.status
+        const pnpmWhichOutput = whichPnpmResults?.output
+        if (hasPnpmLockfile && import.meta.dirname.split(path.sep).includes('.pnpm') && pnpmFound && pnpmWhichOutput) {
+          execPath = pnpmWhichOutput
+        }
       }
+
+      const isYarn = process.env['npm_config_user_agent']?.startsWith('yarn')
+      const isPnpm = Boolean(process.env['PNPM_SCRIPT_SRC_DIR'])
+      const isNpm = !isYarn && !isPnpm
+
+      const spawnArgs = ['run']
+
+      if (npmPathIsJs && npmPath) {
+        spawnArgs.unshift(npmPath)
+      }
+      if (isNpm) {
+        Array.prototype.push.apply(spawnArgs, options.prefixOptions)
+      } else if (options.prefixOptions.indexOf('--silent') !== -1) {
+        spawnArgs.push('--silent')
+      }
+      Array.prototype.push.apply(spawnArgs, parseArgs(task).map(cleanTaskArg))
+
+      finalExecPath = execPath
+      finalSpawnArgs = spawnArgs
     }
 
-    const isYarn = process.env['npm_config_user_agent']?.startsWith('yarn')
-    const isPnpm = Boolean(process.env['PNPM_SCRIPT_SRC_DIR'])
-    const isNpm = !isYarn && !isPnpm
-
-    const spawnArgs = ['run']
-
-    if (npmPathIsJs && npmPath) {
-      spawnArgs.unshift(npmPath)
-    }
-    if (isNpm) {
-      Array.prototype.push.apply(spawnArgs, options.prefixOptions)
-    } else if (options.prefixOptions.indexOf('--silent') !== -1) {
-      spawnArgs.push('--silent')
-    }
-    Array.prototype.push.apply(spawnArgs, parseArgs(task).map(cleanTaskArg))
-
-    const child = await spawn(execPath, spawnArgs, spawnOptions)
+    const child = await spawn(finalExecPath, finalSpawnArgs, spawnOptions)
     cp = child
 
     // Piping stdio.

--- a/test-workspace/package.json
+++ b/test-workspace/package.json
@@ -41,7 +41,10 @@
     "test-task:delayed": "node tasks/output-with-delay.cjs",
     "test-task:yarn": "node ../bin/npm-run-all/index.js test-task:append:{a,b} --npm-path yarn",
     "!test": "node tasks/append1.cjs X",
-    "?test": "node tasks/append1.cjs Q"
+    "?test": "node tasks/append1.cjs Q",
+    "pretest-task:node-run-lifecycle": "node tasks/append1.cjs pre",
+    "test-task:node-run-lifecycle": "node tasks/append1.cjs main",
+    "posttest-task:node-run-lifecycle": "node tasks/append1.cjs post"
   },
   "repository": {
     "type": "git",

--- a/test/node-run.js
+++ b/test/node-run.js
@@ -1,0 +1,108 @@
+/**
+ * @author Bret Comnes
+ * @copyright 2026 Bret Comnes. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+import { test, describe, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import nodeApi from '#lib'
+import { delay, result, removeResult, runAll, runPar, runSeq } from './lib/util.cjs'
+
+// ------------------------------------------------------------------------------
+// Test
+// ------------------------------------------------------------------------------
+
+describe('[node-run]', () => {
+  before(() => process.chdir('test-workspace'))
+  after(() => process.chdir('..'))
+
+  beforeEach(() => delay(1000).then(removeResult))
+
+  describe('should run tasks sequentially with --node-run:', () => {
+    test('Node API', async () => {
+      const results = await nodeApi(
+        ['test-task:append a', 'test-task:append b'],
+        { parallel: false, nodeRun: true }
+      )
+      assert.ok(results != null)
+      assert.strictEqual(results.length, 2)
+      assert.strictEqual(results[0]?.code, 0)
+      assert.strictEqual(results[1]?.code, 0)
+      assert.strictEqual(result(), 'aabb')
+    })
+
+    test('run-s command (--node-run)', async () => {
+      await runSeq(['--node-run', 'test-task:append a', 'test-task:append b'])
+      assert.strictEqual(result(), 'aabb')
+    })
+
+    test('run-s command (-x)', async () => {
+      await runSeq(['-x', 'test-task:append a', 'test-task:append b'])
+      assert.strictEqual(result(), 'aabb')
+    })
+
+    test('npm-run-all command (--node-run)', async () => {
+      await runAll(['--node-run', 'test-task:append a', 'test-task:append b'])
+      assert.strictEqual(result(), 'aabb')
+    })
+  })
+
+  describe('should run tasks in parallel with --node-run:', () => {
+    /** @param {string | null} r */
+    function assertParallelResult (r) {
+      assert.ok(
+        r === 'abab' || r === 'baba' || r === 'abba' || r === 'baab',
+        `Expected interleaved parallel output but got: ${r}`
+      )
+    }
+
+    test('Node API', async () => {
+      const results = await nodeApi(
+        ['test-task:append a', 'test-task:append b'],
+        { parallel: true, nodeRun: true }
+      )
+      assert.ok(results != null)
+      assert.strictEqual(results.length, 2)
+      assert.ok(results.every(r => r.code === 0))
+      assertParallelResult(result())
+    })
+
+    test('run-p command (--node-run)', async () => {
+      await runPar(['--node-run', 'test-task:append a', 'test-task:append b'])
+      assertParallelResult(result())
+    })
+
+    test('run-p command (-x)', async () => {
+      await runPar(['-x', 'test-task:append a', 'test-task:append b'])
+      assertParallelResult(result())
+    })
+
+    test('npm-run-all command (-p --node-run)', async () => {
+      await runAll(['-p', '--node-run', 'test-task:append a', 'test-task:append b'])
+      assertParallelResult(result())
+    })
+  })
+
+  describe('should not run pre/post lifecycle scripts with --node-run:', () => {
+    test('Node API', async () => {
+      const results = await nodeApi(
+        ['test-task:node-run-lifecycle'],
+        { parallel: false, nodeRun: true }
+      )
+      assert.ok(results != null)
+      assert.strictEqual(results[0]?.code, 0)
+      // With npm, pre/post hooks would produce "premainpost". node --run skips them.
+      assert.strictEqual(result(), 'main')
+    })
+
+    test('run-s command', async () => {
+      await runSeq(['--node-run', 'test-task:node-run-lifecycle'])
+      assert.strictEqual(result(), 'main')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds opt-in support for running scripts via `node --run` instead of npm/pnpm/yarn. The per-script startup cost of the package manager CLI adds up fast with `run-p` — this flag lets you skip it entirely.

- New `-x` / `--node-run` flag on all three commands (`run-s`, `run-p`, `npm-run-all`)
- Project-wide opt-in via `package.json`: `"npm-run-all2": { "nodeRun": true }`
- Short flags can be combined as usual (e.g. `-lx`)

## Intentional limitations (inherited from `node --run`)

- No `pre`/`post` lifecycle hooks
- No `npm_*` environment variable injection (`NODE_RUN_SCRIPT_NAME` and `NODE_RUN_PACKAGE_JSON_PATH` are set instead)
- `node_modules/.bin` **is** still added to PATH (traverses up to root)

Because of these limitations the flag is strictly opt-in and never the default.

## Changes

| File | What changed |
|------|-------------|
| `bin/common/parse-cli-args.js` | Added `nodeRun` field, `-x`/`--node-run` cases, extended `CONCAT_OPTIONS` regex |
| `lib/run-task.js` | New execution branch: skips package manager detection, spawns `node --run <script> [-- args]` |
| `lib/index.js` | Threads `nodeRun` option; reads `package.json` config opt-in (requires `true` boolean) |
| `bin/run-{s,p}/main.js`, `bin/npm-run-all/main.js` | Pass `nodeRun` through to `runAll()` |
| `docs/run-s.md`, `docs/run-p.md`, `docs/npm-run-all.md` | Document the new flag |

Closes #155