### PR TITLE
Glob patterns that match no tasks now succeed silently

### DIFF
--- a/lib/match-tasks.js
+++ b/lib/match-tasks.js
@@ -18,12 +18,14 @@ import picomatch from 'picomatch'
 
 const COLON_OR_SLASH = /[:/]/g
 const CONVERT_MAP = /** @type {const} */ ({ ':': '/', '/': ':' })
+const GLOB_CHARS = /[*?[{]/
 
 /**
  * @typedef TaskFilter
  * @property {(candidate: string) => boolean} match - Pattern matcher.
  * @property {string} task - The task pattern without arguments.
  * @property {string} args - Arguments appended to matched tasks.
+ * @property {boolean} isGlob - Whether the task pattern contains glob characters.
  */
 
 /**
@@ -50,12 +52,14 @@ function createFilter (pattern) {
   const spacePos = trimmed.indexOf(' ')
   const task = spacePos < 0 ? trimmed : trimmed.slice(0, spacePos)
   const args = spacePos < 0 ? '' : trimmed.slice(spacePos)
-  const match = picomatch(swapColonAndSlash(task), {
+  const swapped = swapColonAndSlash(task)
+  const isGlob = GLOB_CHARS.test(swapped)
+  const match = picomatch(swapped, {
     nonegate: true,
     strictSlashes: true,
   })
 
-  return { match, task, args }
+  return { match, task, args, isGlob }
 }
 
 /**
@@ -126,7 +130,7 @@ export default function matchTasks (taskList, patterns) {
       taskSet.add(filter.task + filter.args, filter.task)
       found = true
     }
-    if (!found) {
+    if (!found && !filter.isGlob) {
       unknownSet[filter.task] = true
     }
   }

--- a/lib/match-tasks.js
+++ b/lib/match-tasks.js
@@ -18,7 +18,6 @@ import picomatch from 'picomatch'
 
 const COLON_OR_SLASH = /[:/]/g
 const CONVERT_MAP = /** @type {const} */ ({ ':': '/', '/': ':' })
-const GLOB_CHARS = /[*?[{]/
 
 /**
  * @typedef TaskFilter
@@ -53,7 +52,7 @@ function createFilter (pattern) {
   const task = spacePos < 0 ? trimmed : trimmed.slice(0, spacePos)
   const args = spacePos < 0 ? '' : trimmed.slice(spacePos)
   const swapped = swapColonAndSlash(task)
-  const isGlob = GLOB_CHARS.test(swapped)
+  const { isGlob } = picomatch.scan(swapped)
   const match = picomatch(swapped, {
     nonegate: true,
     strictSlashes: true,

--- a/test/pattern.js
+++ b/test/pattern.js
@@ -160,15 +160,21 @@ describe('[pattern] it should run matched tasks if glob like patterns are given.
     })
 
     test('npm-run-all command', async () => {
-      await runAll(['!test-task:**'])
+      const stderr = new BufferStream()
+      await runAll(['!test-task:**'], undefined, stderr)
+      assert.strictEqual(stderr.value, '')
     })
 
     test('run-s command', async () => {
-      await runSeq(['!test-task:**'])
+      const stderr = new BufferStream()
+      await runSeq(['!test-task:**'], undefined, stderr)
+      assert.strictEqual(stderr.value, '')
     })
 
     test('run-p command', async () => {
-      await runPar(['!test-task:**'])
+      const stderr = new BufferStream()
+      await runPar(['!test-task:**'], undefined, stderr)
+      assert.strictEqual(stderr.value, '')
     })
   })
 
@@ -179,15 +185,21 @@ describe('[pattern] it should run matched tasks if glob like patterns are given.
     })
 
     test('npm-run-all command', async () => {
-      await runAll(['nonexistent:*'])
+      const stderr = new BufferStream()
+      await runAll(['nonexistent:*'], undefined, stderr)
+      assert.strictEqual(stderr.value, '')
     })
 
     test('run-s command', async () => {
-      await runSeq(['nonexistent:*'])
+      const stderr = new BufferStream()
+      await runSeq(['nonexistent:*'], undefined, stderr)
+      assert.strictEqual(stderr.value, '')
     })
 
     test('run-p command', async () => {
-      await runPar(['nonexistent:*'])
+      const stderr = new BufferStream()
+      await runPar(['nonexistent:*'], undefined, stderr)
+      assert.strictEqual(stderr.value, '')
     })
   })
 

--- a/test/pattern.js
+++ b/test/pattern.js
@@ -153,45 +153,41 @@ describe('[pattern] it should run matched tasks if glob like patterns are given.
     })
   })
 
-  describe('"!test-task:**" should not match to anything', () => {
+  describe('"!test-task:**" is a glob that matches nothing, so it should succeed silently', () => {
     test('Node API', async () => {
-      try {
-        await nodeApi('!test-task:**')
-        assert.fail('should not match')
-      } catch (err) {
-        assert.ok(err instanceof Error, 'err should be an Error')
-        assert.match(err.message, /not found/i, `Expected error message to contain 'not found', but got: ${err.message}`)
-      }
+      const result = await nodeApi('!test-task:**')
+      assert.deepStrictEqual(result, [])
     })
 
     test('npm-run-all command', async () => {
-      const stderr = new BufferStream()
-      try {
-        await runAll(['!test-task:**'], undefined, stderr)
-        assert.fail('should not match')
-      } catch (_err) {
-        assert.match(stderr.value, /not found/i, `Expected stderr to contain 'not found', but got: ${stderr.value}`)
-      }
+      await runAll(['!test-task:**'])
     })
 
     test('run-s command', async () => {
-      const stderr = new BufferStream()
-      try {
-        await runSeq(['!test-task:**'], undefined, stderr)
-        assert.fail('should not match')
-      } catch (_err) {
-        assert.match(stderr.value, /not found/i, `Expected stderr to contain 'not found', but got: ${stderr.value}`)
-      }
+      await runSeq(['!test-task:**'])
     })
 
     test('run-p command', async () => {
-      const stderr = new BufferStream()
-      try {
-        await runPar(['!test-task:**'], undefined, stderr)
-        assert.fail('should not match')
-      } catch (_err) {
-        assert.match(stderr.value, /not found/i, `Expected stderr to contain 'not found', but got: ${stderr.value}`)
-      }
+      await runPar(['!test-task:**'])
+    })
+  })
+
+  describe('"nonexistent:*" is a glob that matches nothing, so it should succeed silently', () => {
+    test('Node API', async () => {
+      const result = await nodeApi('nonexistent:*')
+      assert.deepStrictEqual(result, [])
+    })
+
+    test('npm-run-all command', async () => {
+      await runAll(['nonexistent:*'])
+    })
+
+    test('run-s command', async () => {
+      await runSeq(['nonexistent:*'])
+    })
+
+    test('run-p command', async () => {
+      await runPar(['nonexistent:*'])
     })
   })
 


### PR DESCRIPTION
## Summary

- Glob patterns (containing `*`, `?`, `[`, or `{`) that match no npm scripts now exit with code 0 instead of throwing `Task not found`.
- Literal task names that don't exist still throw as before.
- Updated the `'"!test-task:**" should not match to anything'` test suite to expect silent success.
- Added a new `'"nonexistent:*" is a glob that matches nothing'` test suite covering all four CLI entry points.

## Why

Discussed in #149. A common pattern is to scaffold standardized `package.json` scripts up-front (e.g. `"lint": "run-p 'lint:*'"`) before any sub-scripts exist, so new packages pass CI out of the box. The current error made that impossible without a placeholder script hack.

The owner's conclusion was to treat this as a small breaking change rather than add a flag — matching how array methods behave on empty inputs (no error, just no work done).

## Reviewer notes

- The change is entirely in [`lib/match-tasks.js`](lib/match-tasks.js). A `GLOB_CHARS` regex detects wildcard patterns; non-glob patterns that resolve to nothing still throw.
- The built-in `restart`/`env` task allowlist is unaffected.

Closes #149