### PR TITLE
fix: update `help.js` to include `--node-run` option details

### DIFF
--- a/bin/npm-run-all/help.js
+++ b/bin/npm-run-all/help.js
@@ -65,7 +65,7 @@ Options:
                                is still added to PATH. Sets NODE_RUN_SCRIPT_NAME
                                and NODE_RUN_PACKAGE_JSON_PATH instead.
                                Can also be enabled project-wide by setting
-                               `"npm-run-all2": { "nodeRun": true }` in
+                               \`"npm-run-all2": { "nodeRun": true }\` in
                                package.json.
 
 Examples:

--- a/bin/npm-run-all/help.js
+++ b/bin/npm-run-all/help.js
@@ -58,6 +58,15 @@ Options:
                                     'npm run foo && npm run bar'.
                                '--serial' is a synonym of '--sequential'.
     --silent   - - - - - - - - Set 'silent' to the log level of npm.
+    -x, --node-run   - - - - - Use \`node --run\` to execute scripts instead of
+                               the package manager. This is faster but
+                               intentionally omits: pre/post lifecycle hooks
+                               and npm_* environment variables. node_modules/.bin
+                               is still added to PATH. Sets NODE_RUN_SCRIPT_NAME
+                               and NODE_RUN_PACKAGE_JSON_PATH instead.
+                               Can also be enabled project-wide by setting
+                               `"npm-run-all2": { "nodeRun": true }` in
+                               package.json.
 
 Examples:
     $ npm-run-all --serial clean lint build:**


### PR DESCRIPTION
Hello,

I noticed that the newly added `-x` and `--node-run` flags were added to the Markdown documents, but were missing from the help description shown with the `-h` flag, I added them.

I think it was missed by mistake in https://github.com/bcomnes/npm-run-all2/commit/72b98eeb1091f5aeab6205d85abe9662e34d52c4