### PR TITLE
fix: bump shell-quote to ^1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "picomatch": "^4.0.2",
     "pidtree": "^0.6.0",
     "read-package-json-fast": "^6.0.0",
-    "shell-quote": "^1.7.3",
+    "shell-quote": "^1.8.4",
     "which": "^7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Resolve shell-quote to non-vulnerable version. https://github.com/advisories/GHSA-w7jw-789q-3m8p

Closes https://github.com/bcomnes/npm-run-all2/issues/235