### PR TITLE
chore: update schema version in .knip.jsonc to v6

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/knip@5/schema.json",
+  "$schema": "https://unpkg.com/knip@6/schema-jsonc.json",
   "entry": ["bin/*/*.js", "test-workspace/tasks/*.cjs"],
   "ignoreDependencies": ["yarn", "spec"]
 }


### PR DESCRIPTION
## Summary

- Update the Knip JSONC schema URL from the v5 schema to the v6 JSONC schema
- Align `.knip.jsonc` with the installed Knip v6 dependency

## Verification

- `npm run check:knip`

## References

- https://knip.dev/reference/configuration#jsonc